### PR TITLE
Clicking anchors after tour ends displays empty popovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,14 @@ This is a product tour library built with Angular (2+).
 
 For Angular 4 use package version 1.0.6 
 
-For Angular 5 use package version 2.0.1
+For Angular 5 use package version 2.0.x
 
 ## Installation
 
 1. `npm i ngx-bootstrap-product-tour ngx-bootstrap bootstrap`
 2. Import `NgxBootstrapProductTourModule.forRoot()` into your app module
 3. Make sure `RouterModule` is imported in your app module
-4. Include bootstrap css somehow - i.e. in your `index.html` add this line:
-    `<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">`
-    or if you are using angular-cli add to `angular-cli.json` add under styles
-    ` "../node_modules/bootstrap/dist/css/bootstrap.min.css"`
+4. Include bootstrap css.
 
 ## Usage
 
@@ -41,7 +38,9 @@ For Angular 5 use package version 2.0.1
     }]);
     ```
 4. Start the tour with `tourService.start()`
-5. Check out the [demo](https://nmilicic.github.io/ngx-bootstrap-product-tour/) for an example or [demo source code](https://github.com/NMilicic/ngx-bootstrap-product-tour/tree/master/src).
+
+## Demo
+Demo page can be found [here](https://nmilicic.github.io/ngx-bootstrap-product-tour/) and it's [source code here](https://github.com/NMilicic/ngx-bootstrap-product-tour/tree/master/src//app).
 
 ## TourService
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "ngx-bootstrap-product-tour",
-  "version": "2.0.0",
-  "description": "Angular 2+ product tour using ngx-bootstrap popover",
+  "version": "2.0.2",
+  "description": "Angular product tour using ngx-bootstrap popover",
   "keywords": [
     "angular",
     "angular2",
     "angular4",
+    "angular5",
     "tour",
     "product tour",
     "ngx-bootstrap"

--- a/src/lib/ngx-bootstrap-product-tour/ngx-bootstrap-product-tour.directive.ts
+++ b/src/lib/ngx-bootstrap-product-tour/ngx-bootstrap-product-tour.directive.ts
@@ -11,7 +11,9 @@ import { Router } from '@angular/router';
 @Directive({
   selector: '[tourAnchor]'
 })
-export class NgxBootstrapPopoverDirective extends PopoverDirective { }
+export class NgxBootstrapPopoverDirective extends PopoverDirective {
+  triggers = '';
+}
 
 @Directive({
   selector: '[tourAnchor]',
@@ -44,6 +46,7 @@ export class NgxBootstrapProductTourDirective implements OnInit, OnDestroy {
     this.popoverDirective.containerClass = step.containerClass ? step.containerClass : '';
     this.popoverDirective.placement = step.placement ? step.placement : 'top';
     this.popoverDirective.container = 'body';
+    this.popoverDirective.triggers = '';
     if (step.orphan) {
       this.popoverDirective.containerClass += ' orphan';
     }

--- a/src/lib/ngx-bootstrap-product-tour/package.json
+++ b/src/lib/ngx-bootstrap-product-tour/package.json
@@ -1,11 +1,12 @@
 {
   "name": "ngx-bootstrap-product-tour",
-  "version": "2.0.1",
-  "description": "Angular 2+ product tour using ngx-bootstrap popover",
+  "version": "2.0.2",
+  "description": "Angular product tour using ngx-bootstrap popover",
   "keywords": [
     "angular",
     "angular2",
     "angular4",
+    "angular5",
     "tour",
     "product tour",
     "ngx-bootstrap"


### PR DESCRIPTION
Overridden ngx-bootstrap popover default trigger.
Fixes #11 